### PR TITLE
fix: allow off-curve addresses

### DIFF
--- a/ts-client/src/examples/actions.ts
+++ b/ts-client/src/examples/actions.ts
@@ -88,7 +88,9 @@ export async function lockLiquidityToFeeVault(
 
   const poolLpAta = getAssociatedTokenAddressSync(
     pool.poolState.lpMint,
-    keypair.publicKey
+    keypair.publicKey,
+    // Only needed if dealing with off-curve addresses, like a Squad.
+    true
   );
 
   const lpAmount = await connection

--- a/ts-client/src/stake-for-fee/helpers/tx.ts
+++ b/ts-client/src/stake-for-fee/helpers/tx.ts
@@ -12,12 +12,16 @@ export const computeUnitIx = (units?: number) => {
 };
 
 export const unwrapSOLInstruction = async (owner: PublicKey) => {
-  const wSolATAAccount = getAssociatedTokenAddressSync(NATIVE_MINT, owner);
+  const wSolATAAccount = getAssociatedTokenAddressSync(
+    NATIVE_MINT,
+    owner,
+    true
+  );
   if (wSolATAAccount) {
     const closedWrappedSolInstruction = createCloseAccountInstruction(
       wSolATAAccount,
       owner,
-      owner,
+      owner
     );
     return closedWrappedSolInstruction;
   }

--- a/ts-client/src/stake-for-fee/index.ts
+++ b/ts-client/src/stake-for-fee/index.ts
@@ -405,7 +405,8 @@ export class StakeForFee {
         connection,
         poolState.lpMint,
         lockEscrowPK,
-        payer
+        payer,
+        true
       );
 
       createEscrowAtaIx && preInstructions.push(createEscrowAtaIx);
@@ -881,15 +882,14 @@ export class StakeForFee {
       .remainingAccounts(remainingAccounts)
       .transaction();
 
-    const [{ blockhash, lastValidBlockHeight }, setCUIx] =
-      await Promise.all([
-        this.connection.getLatestBlockhash(), 
-        getEstimatedComputeUnitIxWithBuffer(
-          this.stakeForFeeProgram.provider.connection,
-          transaction.instructions,
-          owner,
-        )
-      ]);
+    const [{ blockhash, lastValidBlockHeight }, setCUIx] = await Promise.all([
+      this.connection.getLatestBlockhash(),
+      getEstimatedComputeUnitIxWithBuffer(
+        this.stakeForFeeProgram.provider.connection,
+        transaction.instructions,
+        owner
+      ),
+    ]);
     transaction.instructions.unshift(setCUIx);
 
     return new Transaction({
@@ -979,22 +979,21 @@ export class StakeForFee {
       .remainingAccounts(remainingAccounts)
       .transaction();
 
-      const [{ blockhash, lastValidBlockHeight }, setCUIx] =
-      await Promise.all([
-        this.connection.getLatestBlockhash(), 
-        getEstimatedComputeUnitIxWithBuffer(
-          this.stakeForFeeProgram.provider.connection,
-          transaction.instructions,
-          owner,
-        )
-      ]);
+    const [{ blockhash, lastValidBlockHeight }, setCUIx] = await Promise.all([
+      this.connection.getLatestBlockhash(),
+      getEstimatedComputeUnitIxWithBuffer(
+        this.stakeForFeeProgram.provider.connection,
+        transaction.instructions,
+        owner
+      ),
+    ]);
     transaction.instructions.unshift(setCUIx);
 
     return new Transaction({
-        blockhash,
-        lastValidBlockHeight,
-        feePayer: owner,
-      }).add(transaction);
+      blockhash,
+      lastValidBlockHeight,
+      feePayer: owner,
+    }).add(transaction);
   }
 
   /**
@@ -1031,7 +1030,8 @@ export class StakeForFee {
 
     const userStakeTokenKey = getAssociatedTokenAddressSync(
       this.accountStates.feeVault.stakeMint,
-      owner
+      owner,
+      true
     );
 
     const remainingAccounts: Array<AccountMeta> = [];
@@ -1082,15 +1082,14 @@ export class StakeForFee {
       .remainingAccounts(remainingAccounts)
       .transaction();
 
-      const [{ blockhash, lastValidBlockHeight }, setCUIx] =
-      await Promise.all([
-        this.connection.getLatestBlockhash(), 
-        getEstimatedComputeUnitIxWithBuffer(
-          this.stakeForFeeProgram.provider.connection,
-          transaction.instructions,
-          owner,
-        )
-      ]);
+    const [{ blockhash, lastValidBlockHeight }, setCUIx] = await Promise.all([
+      this.connection.getLatestBlockhash(),
+      getEstimatedComputeUnitIxWithBuffer(
+        this.stakeForFeeProgram.provider.connection,
+        transaction.instructions,
+        owner
+      ),
+    ]);
     transaction.instructions.unshift(setCUIx);
 
     return new Transaction({
@@ -1169,15 +1168,14 @@ export class StakeForFee {
       .preInstructions(preInstructions)
       .transaction();
 
-      const [{ blockhash, lastValidBlockHeight }, setCUIx] =
-      await Promise.all([
-        this.connection.getLatestBlockhash(), 
-        getEstimatedComputeUnitIxWithBuffer(
-          this.stakeForFeeProgram.provider.connection,
-          transaction.instructions,
-          owner,
-        )
-      ]);
+    const [{ blockhash, lastValidBlockHeight }, setCUIx] = await Promise.all([
+      this.connection.getLatestBlockhash(),
+      getEstimatedComputeUnitIxWithBuffer(
+        this.stakeForFeeProgram.provider.connection,
+        transaction.instructions,
+        owner
+      ),
+    ]);
     transaction.instructions.unshift(setCUIx);
 
     return new Transaction({


### PR DESCRIPTION
Added flags to certain `getAssociatedTokenAddressSync` invocations to fix issues with off-curve wallets (like Squads)