### PR TITLE
fix: move damm dep from dev dependency to regular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/stake-for-fee [1.0.9] (PR #33)(https://github.com/MeteoraAg/stake-for-fee-sdk/pull/33)
+
+### Fixed
+
+- Move `@mercurial-finance/dynamic-amm-sdk` from a dev dependency to a regular dependency.
+
 ## common [0.0.1] (PR #28)(https://github.com/MeteoraAg/stake-for-fee-sdk/pull/28)
 
 - PDA helper to derive accounts

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "0.29.0",
     "@coral-xyz/borsh": "^0.30.1",
+    "@mercurial-finance/dynamic-amm-sdk": "^1.1.23",
     "@solana-developers/helpers": "^2.5.6",
     "@solana/spl-token": "^0.4.8",
     "@solana/web3.js": "^1.98.0",
@@ -26,7 +27,6 @@
     "decimal.js": "^10.4.3"
   },
   "devDependencies": {
-    "@mercurial-finance/dynamic-amm-sdk": "^1.1.23",
     "@types/bn.js": "^5.1.6",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.10.0",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/m3m3",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
`@mercurial-finance/dynamic-amm-sdk` is listed as a dev dependency: https://github.com/MeteoraAg/stake-for-fee-sdk/blob/3bae081b14c065b88abfbee39e86b6e91cd55a39/ts-client/package.json#L29

However, here it is used as a regular dependency: https://github.com/MeteoraAg/stake-for-fee-sdk/blob/3bae081b14c065b88abfbee39e86b6e91cd55a39/ts-client/src/stake-for-fee/index.ts#L70

This PR fixes the issue.